### PR TITLE
wip: relay mode

### DIFF
--- a/packages/graphql-live-query/src/LiveExecutionResult.ts
+++ b/packages/graphql-live-query/src/LiveExecutionResult.ts
@@ -1,3 +1,9 @@
 import type { ExecutionResult } from "graphql";
 
-export type LiveExecutionResult = ExecutionResult & { isLive?: true };
+export type LiveExecutionResult = ExecutionResult & {
+  isLive?: true;
+  /**
+   * experimental path property for live queries that update at a document at a certain path.
+   */
+  path?: Array<string | number> | undefined;
+};

--- a/packages/in-memory-live-query-store/src/ResourceTracker.spec.ts
+++ b/packages/in-memory-live-query-store/src/ResourceTracker.spec.ts
@@ -9,9 +9,9 @@ it("can track a resource", () => {
   const events = new Set(["a", "b"]);
   resourceTracker.track(1, new Set(), events);
   let result = resourceTracker.getRecordsForIdentifiers(["c"]);
-  expect([...result]).toEqual([]);
+  expect(result).toEqual(new Map());
   result = resourceTracker.getRecordsForIdentifiers(["a"]);
-  expect([...result]).toEqual([1]);
+  expect(result).toEqual(new Map([[1, new Set(["a"])]]));
 });
 
 it("can update the tracked resources", () => {
@@ -19,12 +19,12 @@ it("can update the tracked resources", () => {
   const events = new Set(["a", "b"]);
   resourceTracker.track(1, new Set(), events);
   let result = resourceTracker.getRecordsForIdentifiers(["a"]);
-  expect([...result]).toEqual([1]);
+  expect(result).toEqual(new Map([[1, new Set(["a"])]]));
   resourceTracker.track(1, events, new Set(["c"]));
   result = resourceTracker.getRecordsForIdentifiers(["a"]);
-  expect([...result]).toEqual([]);
+  expect(result).toEqual(new Map());
   result = resourceTracker.getRecordsForIdentifiers(["c"]);
-  expect([...result]).toEqual([1]);
+  resourceTracker.track(1, events, new Set(["c"]));
 });
 
 it("can track multiple resources", () => {
@@ -32,8 +32,13 @@ it("can track multiple resources", () => {
   const events = new Set(["a", "b"]);
   resourceTracker.track(1, new Set(), events);
   resourceTracker.track(2, new Set(), events);
-  let result = resourceTracker.getRecordsForIdentifiers(["a"]);
-  expect([...result]).toEqual([1, 2]);
+  const result = resourceTracker.getRecordsForIdentifiers(["a"]);
+  expect(result).toEqual(
+    new Map([
+      [1, new Set(["a"])],
+      [2, new Set(["a"])],
+    ])
+  );
 });
 
 it("can release a tracked resource", () => {

--- a/packages/in-memory-live-query-store/src/ResourceTracker.ts
+++ b/packages/in-memory-live-query-store/src/ResourceTracker.ts
@@ -67,19 +67,28 @@ export class ResourceTracker<TRecord> {
   }
 
   /**
-   * Get all records that subscribes to a specific set of identifiers
+   * Get all records that subscribes to a specific set of identifiers with a set identifiers that are hits for each record.
    */
-  getRecordsForIdentifiers(identifiers: Array<string>): Set<TRecord> {
-    const records = new Set<TRecord>();
+  getRecordsForIdentifiers(
+    identifiers: Array<string>
+  ): Map<TRecord, Set<string>> {
+    const recordWithHits = new Map<TRecord, Set<string>>();
     for (const identifier of identifiers) {
       const recordSet = this._trackedResources.get(identifier);
-      if (recordSet) {
-        for (const record of recordSet) {
-          records.add(record);
+      if (isNone(recordSet)) {
+        continue;
+      }
+
+      for (const record of recordSet) {
+        let identifierHits = recordWithHits.get(record);
+        if (isNone(identifierHits)) {
+          identifierHits = new Set();
+          recordWithHits.set(record, identifierHits);
         }
+        identifierHits.add(identifier);
       }
     }
 
-    return records;
+    return recordWithHits;
   }
 }

--- a/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.spec.ts
+++ b/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.spec.ts
@@ -1,0 +1,180 @@
+import { buildSchema, parse, print } from "graphql";
+import { buildNodeInterfaceRefetchQueryDocuments } from "./buildNodeInterfaceRefetchQueryDocuments";
+
+const getSchema = () =>
+  buildSchema(/* GraphQL */ `
+    interface Node {
+      id: ID!
+    }
+
+    type Position2D {
+      x: Float!
+      y: Float!
+    }
+
+    type MapGrid implements Node {
+      id: ID!
+      offset: Position2D!
+      columnWidth: Float!
+      columnHeight: Float!
+    }
+
+    type MapToken implements Node {
+      id: ID!
+      position: Position2D!
+      label: String!
+    }
+
+    type Map implements Node {
+      id: ID!
+      title: String!
+      grid: MapGrid
+      tokens: [MapToken!]!
+    }
+
+    type Query {
+      node(id: ID!): Node
+      activeMap: Map
+    }
+  `);
+
+test("it can extract a basic resource", () => {
+  const schema = getSchema();
+
+  const operationAST = parse(/* GraphQL */ `
+    query {
+      activeMap {
+        id
+        title
+      }
+    }
+  `);
+
+  const result = buildNodeInterfaceRefetchQueryDocuments(schema, operationAST);
+  const document = result.get("activeMap")!;
+
+  expect(document).toBeDefined();
+  expect(print(document)).toMatchInlineSnapshot(`
+    "query liveNode($id: ID!) {
+      node(id: $id) {
+        ... on Map {
+          id
+          title
+        }
+      }
+    }
+    "
+  `);
+});
+
+it("can extract multiple flat resources", () => {
+  const schema = getSchema();
+
+  const operationAST = parse(/* GraphQL */ `
+    query {
+      activeMap {
+        id
+        title
+        grid {
+          id
+          offset {
+            x
+            y
+          }
+          columnWidth
+          columnHeight
+        }
+      }
+    }
+  `);
+
+  const result = buildNodeInterfaceRefetchQueryDocuments(schema, operationAST);
+
+  const mapDocument = result.get("activeMap")!;
+  expect(mapDocument).toBeDefined();
+  expect(print(mapDocument)).toMatchInlineSnapshot(`
+    "query liveNode($id: ID!) {
+      node(id: $id) {
+        ... on Map {
+          id
+          title
+        }
+      }
+    }
+    "
+  `);
+
+  const mapGridDocument = result.get("activeMap.grid")!;
+  expect(mapGridDocument).toBeDefined();
+  expect(print(mapGridDocument)).toMatchInlineSnapshot(`
+      "query liveNode($id: ID!) {
+        node(id: $id) {
+          ... on MapGrid {
+            id
+            offset {
+              x
+              y
+            }
+            columnWidth
+            columnHeight
+          }
+        }
+      }
+      "
+  `);
+});
+
+it("can extract list resources", () => {
+  const schema = getSchema();
+
+  const operationAST = parse(/* GraphQL */ `
+    query {
+      activeMap {
+        id
+        title
+        tokens {
+          id
+          label
+          position {
+            x
+            y
+          }
+        }
+      }
+    }
+  `);
+
+  const result = buildNodeInterfaceRefetchQueryDocuments(schema, operationAST);
+
+  const mapDocument = result.get("activeMap")!;
+  expect(mapDocument).toBeDefined();
+  expect(print(mapDocument)).toMatchInlineSnapshot(`
+    "query liveNode($id: ID!) {
+      node(id: $id) {
+        ... on Map {
+          id
+          title
+        }
+      }
+    }
+    "
+  `);
+
+  const mapGridDocument = result.get("activeMap.tokens")!;
+  expect(mapGridDocument).toBeDefined();
+  expect(print(mapGridDocument)).toMatchInlineSnapshot(`
+    "query liveNode($id: ID!) {
+      node(id: $id) {
+        ... on MapToken {
+          id
+          label
+          position {
+            x
+            y
+          }
+        }
+      }
+    }
+    "
+  `);
+});

--- a/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.ts
+++ b/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.ts
@@ -14,6 +14,8 @@ import {
   GraphQLType,
   isListType,
   isNonNullType,
+  InlineFragmentNode,
+  FragmentDefinitionNode,
 } from "graphql";
 import { isNone } from "./Maybe";
 
@@ -104,9 +106,9 @@ export const buildNodeInterfaceRefetchQueryDocuments = (
     operationAST,
     visitWithTypeInfo(typeInfo, {
       OperationDefinition(node) {
-        if (node.operation !== "query" || node.name !== operationName) {
-          return false;
-        }
+        // if (node.operation !== "query" || node.name !== operationName) {
+        //   return false;
+        // }
       },
       Field: {
         enter(node) {
@@ -124,6 +126,21 @@ export const buildNodeInterfaceRefetchQueryDocuments = (
                   if (isObjectTypeThatImplementsNodeInterface(fieldType)) {
                     return null;
                   }
+                },
+                FragmentSpread(def) {
+                  console.log("encounter");
+                  const fragment: FragmentDefinitionNode = operationAST.definitions.find(
+                    (doc) =>
+                      doc.kind === "FragmentDefinition" &&
+                      doc.name.value === def.name.value
+                  ) as any;
+                  const inlineSpread: InlineFragmentNode = {
+                    kind: "InlineFragment",
+                    typeCondition: fragment.typeCondition,
+                    selectionSet: fragment.selectionSet,
+                  };
+
+                  return inlineSpread;
                 },
               })
             );

--- a/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.ts
+++ b/packages/in-memory-live-query-store/src/buildNodeInterfaceRefetchQueryDocuments.ts
@@ -1,0 +1,144 @@
+import {
+  DocumentNode,
+  GraphQLSchema,
+  visit,
+  isObjectType,
+  isInterfaceType,
+  GraphQLInterfaceType,
+  SelectionSetNode,
+  parse,
+  FieldNode,
+  GraphQLObjectType,
+  visitWithTypeInfo,
+  TypeInfo,
+  GraphQLType,
+  isListType,
+  isNonNullType,
+} from "graphql";
+import { isNone } from "./Maybe";
+
+const getNodeInterfaceTypeFromSchema = (schema: GraphQLSchema) => {
+  const nodeInterfaceType = schema.getType("Node");
+  if (isNone(nodeInterfaceType)) {
+    throw new Error("Schema does not implement the Node interface.");
+  }
+  if (isInterfaceType(nodeInterfaceType) === false) {
+    throw new Error("Schema does not implement the Node interface.");
+  }
+
+  return nodeInterfaceType as GraphQLInterfaceType;
+};
+
+const getWrappedType = (graphQLType: GraphQLType): GraphQLType => {
+  if (isListType(graphQLType) || isNonNullType(graphQLType)) {
+    return getWrappedType(graphQLType.ofType);
+  }
+  return graphQLType;
+};
+
+const getOperationBase = () =>
+  parse(/* GraphQL */ `
+    query liveNode($id: ID!) {
+      node(id: $id) {
+        __typename
+      }
+    }
+  `);
+
+const buildNodeInterfaceQuery = (
+  typeName: string,
+  selectionSet: SelectionSetNode
+) =>
+  visit(getOperationBase(), {
+    Field(fieldNode) {
+      if (fieldNode.name.value === "node") {
+        const field: FieldNode = {
+          ...fieldNode,
+          selectionSet: {
+            kind: "SelectionSet",
+            selections: [
+              {
+                kind: "InlineFragment",
+                typeCondition: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: typeName,
+                  },
+                },
+                selectionSet,
+              },
+            ],
+          },
+        };
+
+        return field;
+      }
+    },
+  });
+
+/**
+ * Extract documents from a graphql query operation that can be executed on the `Query.node` field.
+ * See `buildNodeInterfaceRefetchQueryDocuments.spec.ts` an overview of the API.
+ * This function assumes that both the schema and the operation have passed GraphQL validation and implement the interface Node type and Query.node(id:) field.
+ */
+export const buildNodeInterfaceRefetchQueryDocuments = (
+  schema: GraphQLSchema,
+  operationAST: DocumentNode,
+  operationName?: string
+): Map<string, DocumentNode> => {
+  const queryDocuments = new Map<string, DocumentNode>();
+
+  const nodeInterfaceType = getNodeInterfaceTypeFromSchema(schema);
+
+  const typeInfo = new TypeInfo(schema);
+
+  const isObjectTypeThatImplementsNodeInterface = (
+    graphQLType: GraphQLType
+  ): graphQLType is GraphQLObjectType =>
+    isObjectType(graphQLType) &&
+    graphQLType.getInterfaces().includes(nodeInterfaceType);
+
+  const stack: Array<string> = [];
+  visit(
+    operationAST,
+    visitWithTypeInfo(typeInfo, {
+      OperationDefinition(node) {
+        if (node.operation !== "query" || node.name !== operationName) {
+          return false;
+        }
+      },
+      Field: {
+        enter(node) {
+          const fieldInfo = typeInfo.getFieldDef();
+          stack.push(node.name.value);
+          const fieldType = getWrappedType(fieldInfo.type);
+
+          if (isObjectTypeThatImplementsNodeInterface(fieldType)) {
+            const newNode = visit(
+              node.selectionSet!,
+              visitWithTypeInfo(typeInfo, {
+                Field() {
+                  const fieldInfo = typeInfo.getFieldDef();
+                  const fieldType = getWrappedType(fieldInfo.type);
+                  if (isObjectTypeThatImplementsNodeInterface(fieldType)) {
+                    return null;
+                  }
+                },
+              })
+            );
+            queryDocuments.set(
+              stack.join("."),
+              buildNodeInterfaceQuery(fieldType.name, newNode)
+            );
+          }
+        },
+        leave() {
+          stack.pop();
+        },
+      },
+    })
+  );
+
+  return queryDocuments;
+};


### PR DESCRIPTION
This is an experimental branch that tries to implement the concepts mentioned in https://dev.to/n1ru4l/graphql-live-queries-backed-by-the-relay-specification-3mlo

I also pushed the example app updates in a separate branch for comparison: https://github.com/n1ru4l/graphql-live-query/pull/490/files

# Open questions

## How to handle ObjectType fields that resolve to another ObjectType relations?

```graphql
type Token implements Node {
  id: ID!
  x: Float!
  y: Float!
  image: TokenImage
}

type TokenImage implements Node {
  id: ID!
  uri: String!
}

type Query {
  token(id: ID!): Token
}
```

In case the `Token.image` value is changed (new image attached to the token). We need to invalidate that field. But right now there is now way in the NodeInterface mode for doing that.

We can either invalidate the Token or the TokenImage. Both will result in insufficient updates.

```graphql
query {
  token(id: "Token:1") {
    id
    x
    y
    image {
      id
      url
    }
  }
}
```

Invalidating the Token (`Token:1`) will result in the following query being executed:

```graphql
query {
  node(id: "Token:1") {
    ... on Token {
      id
      x
      y
    }
  }
}
```

Invalidatin the Image will result in the following query being executed:

```graphql
query {
  node(id: "TokenImage:1") {
    ... on TokenImage {
      id
      uri
    }
  }
}
```

Which will not help. We could maybe provide an API similar to this:

```
liveQueryStore.invalidateReplace("TokenImage:1", "TokenImage:2")
```

Which will ensure that 

```graphql
query {
  node(id: "TokenImage:2") {
    ... on TokenImage {
      id
      uri
    }
  }
}
```

is executed instead. But that could be ugly as it may conflict with other fields whose resource has not changed.

This would be more granular and could work because most of the time you have access to all the context in the mutation where the TokenImage might be replaced.

```
liveQueryStore.invalidate({
  on: "Token:1",
  field: "image",
  replaceWith: "TokenImage:2" // null if it got completely removed. Should also throw if field is non nullable.
})
```

This approach is more imperative but could allow is re-executing that part of the query and push it to the client 🤔