### PR TITLE
Add memory store config property for determining identifier field name

### DIFF
--- a/.changeset/gorgeous-pianos-begin.md
+++ b/.changeset/gorgeous-pianos-begin.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/in-memory-live-query-store": patch
+---
+
+add optional identification field parameter to store configuration


### PR DESCRIPTION
Hi there! I have a bit of an arbitrary request, but one that would help prevent me from having to write a good amount of extra code. At work, we use an `_id` field rather than an `id` field, pretty arbitrarily. I figure it couldn't hurt to expose what field the memory store uses to generate its resource identifiers.