### PR TITLE
fix: don't execute operations when offline

### DIFF
--- a/.changeset/perfect-donuts-train.md
+++ b/.changeset/perfect-donuts-train.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/socket-io-graphql-client": patch
+---
+
+Fixed race condition where subscriptions would be duplicated if socket connection was interrupted during initial subscription transmission

--- a/packages/socket-io-graphql-client/src/createSocketIOGraphQLClient.ts
+++ b/packages/socket-io-graphql-client/src/createSocketIOGraphQLClient.ts
@@ -89,9 +89,11 @@ export const createSocketIOGraphQLClient = <TExecutionResult = unknown>(
 
     operations.set(operationId, record);
 
-    if (!isOffline) record.execute();
+    if (!isOffline) {
+      record.execute();
+    }
 
-    const originalReturn = iterator.return;
+    const originalReturn = iterator.return!;
     iterator.return = () => {
       if (operations.delete(operationId) === false) {
         return Promise.resolve({ done: true, value: undefined });
@@ -101,9 +103,7 @@ export const createSocketIOGraphQLClient = <TExecutionResult = unknown>(
         id: operationId,
       });
 
-      return originalReturn
-        ? originalReturn()
-        : Promise.resolve({ done: true, value: undefined });
+      return originalReturn();
     };
 
     return iterator;

--- a/packages/socket-io-graphql-client/src/createSocketIOGraphQLClient.ts
+++ b/packages/socket-io-graphql-client/src/createSocketIOGraphQLClient.ts
@@ -88,7 +88,8 @@ export const createSocketIOGraphQLClient = <TExecutionResult = unknown>(
     };
 
     operations.set(operationId, record);
-    record.execute();
+
+    if (!isOffline) record.execute();
 
     const originalReturn = iterator.return;
     iterator.return = () => {


### PR DESCRIPTION
This change prevents executing operations that are passed to the link if the socket is in the offline state. Without this change, there is a race condition where if the socket is killed and restarted while subscription operations are still being sent to the link from something like Apollo, the operations are duplicated once reconnected, causing duplicate subscriptions.

This happens because the `execute` on each operation will survive the reconnection if it is fast enough, so that original `execute` will complete, and then we re-execute it from the `operations` list in `onConnect`.