### PR TITLE
Don't publish empty patches

### DIFF
--- a/.changeset/lovely-planets-refuse.md
+++ b/.changeset/lovely-planets-refuse.md
@@ -1,0 +1,7 @@
+---
+"@n1ru4l/graphql-live-query-patch": minor
+"@n1ru4l/graphql-live-query-patch-jsondiffpatch": minor
+"@n1ru4l/graphql-live-query-patch-json-patch": minor
+---
+
+omit empty patches from being sent to clients

--- a/packages/graphql-live-query-patch-json-diff/src/applyJSONDiffPatch.ts
+++ b/packages/graphql-live-query-patch-json-diff/src/applyJSONDiffPatch.ts
@@ -1,9 +1,10 @@
 import { ApplyPatchFunction } from "@n1ru4l/graphql-live-query-patch";
 import * as jsondiffpatch from "jsondiffpatch";
 
-export const applyJSONDiffPatch: ApplyPatchFunction<
-  jsondiffpatch.Delta | undefined
-> = (previous, patch): Record<string, unknown> => {
+export const applyJSONDiffPatch: ApplyPatchFunction<jsondiffpatch.Delta> = (
+  previous,
+  patch
+): Record<string, unknown> => {
   const patcher = jsondiffpatch.create();
   // @ts-ignore
   const result = patcher.patch(previous, patch);

--- a/packages/graphql-live-query-patch-json-diff/src/applyLiveQueryJSONDiffPatchGenerator.spec.ts
+++ b/packages/graphql-live-query-patch-json-diff/src/applyLiveQueryJSONDiffPatchGenerator.spec.ts
@@ -103,3 +103,45 @@ it("publishes patches for live query results", async () => {
     done: true,
   });
 });
+
+it("doesn't publish empty patches for data that hasn't changed", async () => {
+  async function* source() {
+    yield {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      isLive: true,
+    } as LiveExecutionResult;
+    yield {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      isLive: true,
+    } as LiveExecutionResult;
+  }
+
+  const stream = liveQueryJSONDiffPatchGenerator(source());
+
+  let value = await stream.next();
+  expect(value).toEqual({
+    value: {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      revision: 1,
+    },
+    done: false,
+  });
+  value = await stream.next();
+
+  expect(value).toEqual({
+    value: undefined,
+    done: true,
+  });
+});

--- a/packages/graphql-live-query-patch-json-diff/src/generateJSONDiffPatch.ts
+++ b/packages/graphql-live-query-patch-json-diff/src/generateJSONDiffPatch.ts
@@ -1,9 +1,16 @@
-import type { GeneratePatchFunction } from "@n1ru4l/graphql-live-query-patch";
+import {
+  GeneratePatchFunction,
+  noDiffSymbol,
+} from "@n1ru4l/graphql-live-query-patch";
 import * as jsondiffpatch from "jsondiffpatch";
 
 export const generateJSONDiffPatch: GeneratePatchFunction<
   jsondiffpatch.Delta | undefined
 > = (previous, current) => {
   const patcher = jsondiffpatch.create();
-  return patcher.diff(previous, current);
+  const patch = patcher.diff(previous, current);
+  if (patch === undefined) {
+    return noDiffSymbol;
+  }
+  return patch;
 };

--- a/packages/graphql-live-query-patch-json-patch/src/applyLiveQueryJSONPatchGenerator.spec.ts
+++ b/packages/graphql-live-query-patch-json-patch/src/applyLiveQueryJSONPatchGenerator.spec.ts
@@ -105,3 +105,45 @@ it("publishes patches for live query results", async () => {
     done: true,
   });
 });
+
+it("doesn't publish empty patches for data that hasn't changed", async () => {
+  async function* source() {
+    yield {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      isLive: true,
+    } as LiveExecutionResult;
+    yield {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      isLive: true,
+    } as LiveExecutionResult;
+  }
+
+  const stream = liveQueryJSONPatchGenerator(source());
+
+  let value = await stream.next();
+  expect(value).toEqual({
+    value: {
+      data: {
+        foo: {
+          bar: "kek",
+        },
+      },
+      revision: 1,
+    },
+    done: false,
+  });
+  value = await stream.next();
+
+  expect(value).toEqual({
+    value: undefined,
+    done: true,
+  });
+});

--- a/packages/graphql-live-query-patch-json-patch/src/generateJSONPatch.ts
+++ b/packages/graphql-live-query-patch-json-patch/src/generateJSONPatch.ts
@@ -1,5 +1,11 @@
 import type { GeneratePatchFunction } from "@n1ru4l/graphql-live-query-patch";
 import { Operation, compare } from "fast-json-patch";
 
-export const generateJSONPatch: GeneratePatchFunction<Array<Operation>> =
-  compare;
+export const generateJSONPatch: GeneratePatchFunction<
+  Array<Operation> | undefined
+> = (...args) => {
+  const result = compare(...args);
+  if (result.length > 0) {
+    return result;
+  }
+};

--- a/packages/graphql-live-query-patch-json-patch/src/generateJSONPatch.ts
+++ b/packages/graphql-live-query-patch-json-patch/src/generateJSONPatch.ts
@@ -1,11 +1,13 @@
 import type { GeneratePatchFunction } from "@n1ru4l/graphql-live-query-patch";
+import { noDiffSymbol } from "@n1ru4l/graphql-live-query-patch";
 import { Operation, compare } from "fast-json-patch";
 
-export const generateJSONPatch: GeneratePatchFunction<
-  Array<Operation> | undefined
-> = (...args) => {
+export const generateJSONPatch: GeneratePatchFunction<Array<Operation>> = (
+  ...args
+) => {
   const result = compare(...args);
   if (result.length > 0) {
     return result;
   }
+  return noDiffSymbol;
 };

--- a/packages/graphql-live-query-patch/src/createLiveQueryPatchGenerator.ts
+++ b/packages/graphql-live-query-patch/src/createLiveQueryPatchGenerator.ts
@@ -3,10 +3,16 @@ import type { ExecutionResult } from "graphql";
 import type { ExecutionPatchResult } from "./ExecutionPatchResult";
 import type { ExecutionLivePatchResult } from "./ExecutionLivePatchResult";
 
+/**
+ * Symbol that indicates that there is no diff between the previous and current state and thus no patch must be sent to the client.
+ * This value should be returned from GeneratePatchFunction.
+ */
+export const noDiffSymbol = Symbol("noDiffSymbol");
+
 export type GeneratePatchFunction<PatchPayload = unknown> = (
   previous: Record<string, unknown>,
   current: Record<string, unknown>
-) => PatchPayload;
+) => PatchPayload | typeof noDiffSymbol;
 
 export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
   generatePatch: GeneratePatchFunction<PatchPayload>
@@ -17,7 +23,7 @@ export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
     ExecutionLivePatchResult | ExecutionResult | ExecutionPatchResult
   > {
     let previousValue: LiveExecutionResult["data"] | null = null;
-    let revision = 0;
+    let revision = 1;
 
     for await (const value of asyncIterator) {
       // if it is not live we simply forward everything :)
@@ -29,15 +35,17 @@ export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
 
       const valueToPublish: ExecutionLivePatchResult = {};
 
-      let shouldPublish = true;
-
       if (previousValue) {
         const currentValue = value.data ?? {};
-        valueToPublish.patch = generatePatch(previousValue, currentValue);
-
-        // skip publishing the patch if it's empty.
-        shouldPublish = valueToPublish.patch !== undefined;
+        const patch = generatePatch(previousValue, currentValue);
         previousValue = currentValue;
+
+        if (patch === noDiffSymbol) {
+          continue;
+        }
+
+        valueToPublish.patch = patch;
+        revision++;
       } else {
         previousValue = value.data ?? {};
         if ("data" in value) {
@@ -52,10 +60,8 @@ export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
         valueToPublish.extensions = value.extensions;
       }
 
-      if (shouldPublish) {
-        revision++;
-        valueToPublish.revision = revision;
-        yield valueToPublish;
-      }
+      valueToPublish.revision = revision;
+
+      yield valueToPublish;
     }
   };

--- a/packages/graphql-live-query-patch/src/createLiveQueryPatchGenerator.ts
+++ b/packages/graphql-live-query-patch/src/createLiveQueryPatchGenerator.ts
@@ -27,13 +27,16 @@ export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
         continue;
       }
 
-      revision++;
+      const valueToPublish: ExecutionLivePatchResult = {};
 
-      const valueToPublish: ExecutionLivePatchResult = { revision };
+      let shouldPublish = true;
 
       if (previousValue) {
         const currentValue = value.data ?? {};
         valueToPublish.patch = generatePatch(previousValue, currentValue);
+
+        // skip publishing the patch if it's empty.
+        shouldPublish = valueToPublish.patch !== undefined;
         previousValue = currentValue;
       } else {
         previousValue = value.data ?? {};
@@ -49,6 +52,10 @@ export const createLiveQueryPatchGenerator = <PatchPayload = unknown>(
         valueToPublish.extensions = value.extensions;
       }
 
-      yield valueToPublish;
+      if (shouldPublish) {
+        revision++;
+        valueToPublish.revision = revision;
+        yield valueToPublish;
+      }
     }
   };


### PR DESCRIPTION
For #655 #294
 
This update explicitly checks if `generatePatch` indicates a change, and if not, will skip publishing that patch.

e.g. If the current data looks like: `{ a: 1, b: 2, c: 3 }` and there's an open query such as `{ a, b }`, if `c` changes and we invalidate on the server, it would previously publish an empty patch to that user.

Also, I'm not super familiar with Typescript, so the correct types might need to be added.