### PR TITLE
Add file extension to import

### DIFF
--- a/.changeset/olive-teachers-leave.md
+++ b/.changeset/olive-teachers-leave.md
@@ -1,0 +1,6 @@
+---
+"@n1ru4l/in-memory-live-query-store": patch
+---
+
+Added '.js' file extension to GraphQL `getArgumentValues` import.
+See: https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_mandatory_file_extensions

--- a/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
+++ b/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
@@ -7,7 +7,7 @@ import {
   visitWithTypeInfo,
   visit,
 } from "graphql";
-import { getArgumentValues } from "graphql/execution/values";
+import { getArgumentValues } from "graphql/execution/values.js";
 import { isNone, isSome, Maybe } from "./Maybe";
 
 type MaybeOperationDefinitionNode = OperationDefinitionNode | null;


### PR DESCRIPTION
This fix correctly resolves the import for ESM projects.

See https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_mandatory_file_extensions