### PR TITLE
fix(in-memory-live-query-store): use execute provided to makeExecute

### DIFF
--- a/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
+++ b/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
@@ -309,6 +309,8 @@ export class InMemoryLiveQueryStore {
       let executionCounter = 0;
       let previousIdentifier = new Set<string>(rootFieldIdentifier);
 
+      const localExecuteFn = execute || this._execute;
+
       const record: StoreRecord = {
         iterator,
         pushValue,
@@ -335,7 +337,7 @@ export class InMemoryLiveQueryStore {
             }
           };
 
-          const result = this._execute({
+          const result = localExecuteFn({
             schema,
             document,
             operationName,


### PR DESCRIPTION
This closes #744  