### PR TITLE
Support for custom store invalidations based on predicates

### DIFF
--- a/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
+++ b/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
@@ -444,12 +444,19 @@ export class InMemoryLiveQueryStore {
    * Invalidate queries (and schedule their re-execution) via a resource identifier.
    * @param identifiers A single or list of resource identifiers that should be invalidated.
    */
-  async invalidate(identifiers: Array<string> | string) {
-    if (typeof identifiers === "string") {
-      identifiers = [identifiers];
-    }
+  async invalidate(
+    identifiers: Array<string> | string | ((record: StoreRecord) => boolean)
+  ) {
+    let records: Set<StoreRecord>;
 
-    const records = this._resourceTracker.getRecordsForIdentifiers(identifiers);
+    if (typeof identifiers === "function") {
+      records = this._resourceTracker.getRecordsForPredicate(identifiers);
+    } else {
+      if (typeof identifiers === "string") {
+        identifiers = [identifiers];
+      }
+      records = this._resourceTracker.getRecordsForIdentifiers(identifiers);
+    }
 
     for (const record of records) {
       record.run();

--- a/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
+++ b/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
@@ -35,6 +35,7 @@ type StoreRecord = {
   pushValue: (value: LiveExecutionResult) => void;
   run: () => PromiseOrValue<void>;
   fields: Map<string, ReturnType<typeof getArgumentValues>>;
+  parameters: ExecutionArgs;
 };
 
 type ResourceIdentifierCollectorFunction = (
@@ -322,6 +323,16 @@ export class InMemoryLiveQueryStore {
         typeInfo,
       });
 
+      const executionParameters: ExecutionArgs = {
+        schema,
+        document,
+        operationName,
+        rootValue,
+        contextValue,
+        variableValues,
+        ...additionalArguments,
+      };
+
       const record: StoreRecord = {
         iterator,
         pushValue,
@@ -349,17 +360,12 @@ export class InMemoryLiveQueryStore {
           };
 
           const result = execute({
-            schema,
-            document,
-            operationName,
-            rootValue,
+            ...executionParameters,
             contextValue: {
-              [ORIGINAL_CONTEXT_SYMBOL]: contextValue,
+              [ORIGINAL_CONTEXT_SYMBOL]: executionParameters.contextValue,
               collectResourceIdentifier,
               addResourceIdentifier,
             },
-            variableValues,
-            ...additionalArguments,
           });
 
           // result cannot be a AsyncIterableIterator if the `NoLiveMixedWithDeferStreamRule` was used.
@@ -412,6 +418,7 @@ export class InMemoryLiveQueryStore {
           });
         },
         fields,
+        parameters: executionParameters,
       };
 
       // utils for throttle

--- a/packages/in-memory-live-query-store/src/ResourceTracker.ts
+++ b/packages/in-memory-live-query-store/src/ResourceTracker.ts
@@ -82,4 +82,19 @@ export class ResourceTracker<TRecord> {
 
     return records;
   }
+
+  /**
+   * Get all records that satisfy a specific predicate
+   */
+  getRecordsForPredicate(predicate: (record: TRecord) => boolean) {
+    const records = new Set<TRecord>();
+    for (const recordSet of this._trackedResources.values()) {
+      for (const record of recordSet) {
+        if (!records.has(record) && predicate(record)) {
+          records.add(record);
+        }
+      }
+    }
+    return records;
+  }
 }

--- a/packages/in-memory-live-query-store/src/ResourceTracker.ts
+++ b/packages/in-memory-live-query-store/src/ResourceTracker.ts
@@ -9,8 +9,10 @@ import { isNone } from "./Maybe";
  */
 export class ResourceTracker<TRecord> {
   private _trackedResources: Map<string, Set<TRecord>>;
+  private _allResources: Set<TRecord>;
   constructor() {
     this._trackedResources = new Map();
+    this._allResources = new Set();
   }
 
   /**
@@ -56,6 +58,7 @@ export class ResourceTracker<TRecord> {
    * @param identifiers The list of identifiers
    */
   register(record: TRecord, identifiers: Set<string>): void {
+    this._allResources.add(record);
     this.track(record, new Set(), identifiers);
   }
 
@@ -63,6 +66,7 @@ export class ResourceTracker<TRecord> {
    * Release a record that subscribes to a specific set of identifiers.
    */
   release(record: TRecord, identifiers: Set<string>): void {
+    this._allResources.delete(record);
     this.track(record, identifiers, new Set());
   }
 
@@ -88,11 +92,9 @@ export class ResourceTracker<TRecord> {
    */
   getRecordsForPredicate(predicate: (record: TRecord) => boolean) {
     const records = new Set<TRecord>();
-    for (const recordSet of this._trackedResources.values()) {
-      for (const record of recordSet) {
-        if (!records.has(record) && predicate(record)) {
-          records.add(record);
-        }
+    for (const record of this._allResources) {
+      if (predicate(record)) {
+        records.add(record);
       }
     }
     return records;

--- a/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
+++ b/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
@@ -93,3 +93,31 @@ export const extractLiveQueryRootFieldCoordinates = (params: {
 
   return identifier;
 };
+
+/**
+ * Returns a Map whose keys are the root query type fields and values the corresponding arguments values.
+ */
+export const extractLiveQueryRootFieldArgumentValues = (params: {
+  documentNode: DocumentNode;
+  operationNode: OperationDefinitionNode;
+  typeInfo: TypeInfo;
+  variableValues?: Maybe<Record<string, unknown>>;
+}) => {
+  const info = new Map<string, ReturnType<typeof getArgumentValues>>();
+  visit(
+    params.documentNode,
+    visitWithTypeInfo(params.typeInfo, {
+      Field(fieldNode) {
+        const parentType = params.typeInfo.getParentType();
+        if (isSome(parentType) && parentType.name === "Query") {
+          const fieldDef = params.typeInfo.getFieldDef();
+          info.set(
+            fieldNode.name.value,
+            getArgumentValues(fieldDef, fieldNode, params.variableValues)
+          );
+        }
+      },
+    })
+  );
+  return info;
+};


### PR DESCRIPTION
As discussed [here](https://github.com/n1ru4l/graphql-live-query/discussions/616), it would be interesting to be able to make custom lookups into the ressource tracker, and invalidate records not based on coordinates but on predicates. This makes invalidation logic that cannot be expressed as coordinates really easy. For example _"invalidate all queries where argument foo is greater than x, and argument bar starting with a capital letter"_, or _"invalidate all queries from user with this specific id (from `contextValue`)"_ (this is far fetched, pun intended, but you get the idea).

To make this kind of filtering possible, three things had to be done:

- Adding useful info on the record objects themselves (otherwise there's nothing to filter by). In this implementation, I choose to add two new fields:
  -  `fields`: Contains a `Map` whose keys are the root query fields and whose values are the resolved arguments for each field (the object returned by `getArgumentValues`).
  - `parameters`: Contains the `ExecutionArgs` that are used for the current record.
- Extending `ResourceTracker` to be able to gather records by predicate.
- Extending `InMemoryLiveQueryStore.prototype.invalidate` to accept a predicate function as an argument instead of string coordinates.