### PR TITLE
chore(deps): add dependency on tslib

### DIFF
--- a/packages/graphql-live-query-patch-json-patch/package.json
+++ b/packages/graphql-live-query-patch-json-patch/package.json
@@ -20,12 +20,13 @@
   ],
   "dependencies": {
     "@n1ru4l/graphql-live-query-patch": "^0.7.0",
-    "fast-json-patch": "^3.1.0"
+    "fast-json-patch": "^3.1.0",
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "graphql": "16.0.0-experimental-stream-defer.5",
     "@n1ru4l/graphql-live-query": "*",
-    "@n1ru4l/in-memory-live-query-store": "*"
+    "@n1ru4l/in-memory-live-query-store": "*",
+    "graphql": "16.0.0-experimental-stream-defer.5"
   },
   "peerDependencies": {
     "graphql": "^15.4.0 || ^16.0.0"

--- a/packages/graphql-live-query-patch-jsondiffpatch/package.json
+++ b/packages/graphql-live-query-patch-jsondiffpatch/package.json
@@ -19,13 +19,14 @@
     "real-time"
   ],
   "dependencies": {
+    "@n1ru4l/graphql-live-query-patch": "^0.7.0",
     "@n1ru4l/json-patch-plus": "^0.2.0",
-    "@n1ru4l/graphql-live-query-patch": "^0.7.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "graphql": "16.0.0-experimental-stream-defer.5",
     "@n1ru4l/graphql-live-query": "*",
-    "@n1ru4l/in-memory-live-query-store": "*"
+    "@n1ru4l/in-memory-live-query-store": "*",
+    "graphql": "16.0.0-experimental-stream-defer.5"
   },
   "peerDependencies": {
     "graphql": "^15.4.0 || ^16.0.0"

--- a/packages/in-memory-live-query-store/package.json
+++ b/packages/in-memory-live-query-store/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@graphql-tools/utils": "^8.5.2",
     "@n1ru4l/graphql-live-query": "0.10.0",
-    "@repeaterjs/repeater": "^3.0.4"
+    "@repeaterjs/repeater": "^3.0.4",
+    "tslib": "^2.4.1"
   },
   "peerDependencies": {
     "graphql": "^15.4.0 || ^16.0.0"

--- a/packages/json-patch-plus/package.json
+++ b/packages/json-patch-plus/package.json
@@ -18,7 +18,9 @@
     "diff"
   ],
   "devDependencies": {},
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.1"
+  },
   "peerDependencies": {},
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/socket-io-graphql-client/package.json
+++ b/packages/socket-io-graphql-client/package.json
@@ -32,7 +32,8 @@
     "socket.io-client": "^3.0.1 || ^4.0.0"
   },
   "dependencies": {
-    "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0"
+    "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",
+    "tslib": "^2.4.1"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/socket-io-graphql-server/package.json
+++ b/packages/socket-io-graphql-server/package.json
@@ -24,9 +24,9 @@
     "real-time"
   ],
   "devDependencies": {
-    "typescript": "4.7.4",
     "graphql": "16.0.0-experimental-stream-defer.5",
-    "socket.io": "4.5.2"
+    "socket.io": "4.5.2",
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "graphql": "^15.4.0 || ^16.0.0",
@@ -66,5 +66,8 @@
     "directory": "dist",
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "tslib": "^2.4.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,7 @@
 
 "@app/gql@link:./packages/todo-example/client-apollo/src/gql":
   version "0.0.0"
+  uid ""
 
 "@ardatan/relay-compiler@12.0.0":
   version "12.0.0"
@@ -8456,7 +8457,7 @@ ts-node-dev@2.0.0:
     ts-node "^10.4.0"
     tsconfig "^7.0.0"
 
-ts-node@^10.4.0, ts-node@^10.8.1, ts-node@~10.9.0:
+ts-node@^10.4.0, ts-node@^10.8.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -8500,6 +8501,11 @@ tslib@2.4.0, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsup@^5.11.6:
   version "5.12.9"


### PR DESCRIPTION
With the new npm [isolated mode](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md) in v9.4.1, using undeclared dependencies is now an error (similar to Yarn PnP). This PR adds an explicit dependency on tslib for modules that are built with a reference to tslib.

fixes #967