### PR TITLE
fix: Trigger NoLiveMixedWithDeferStreamRule only if query has @live directive

### DIFF
--- a/packages/graphql-live-query/src/rules/NoLiveMixedWithDeferStreamRule.ts
+++ b/packages/graphql-live-query/src/rules/NoLiveMixedWithDeferStreamRule.ts
@@ -4,16 +4,21 @@ import { getLiveDirectiveNode } from "../getLiveDirectiveNode.js";
 import { isNone } from "../Maybe.js";
 
 export const NoLiveMixedWithDeferStreamRule: ValidationRule = (context) => {
+  let opmatch = false;
   return {
     OperationDefinition(operationDefinitionNode) {
       if (isNone(getLiveDirectiveNode(operationDefinitionNode))) {
         return false;
+      } else {
+        opmatch = true;
       }
     },
     Directive(directiveNode) {
       if (
-        directiveNode.name.value === "defer" ||
-        directiveNode.name.value === "stream"
+        opmatch && (
+          directiveNode.name.value === "defer" ||
+          directiveNode.name.value === "stream"
+        )
       ) {
         context.reportError(
           new GraphQLError(


### PR DESCRIPTION
Some queries with fragments marked with `@defer` would trigger this error without actually having `@live` directive in the query

example query:

```graphql
{
  containers {
    id
    ...TriggerError
  }
}

fragment TriggerError on Container {
  id
  ... on Container @defer {
    stats
  }
}
```