### PR TITLE
Update extractLiveQueryRootFieldCoordinates to handle FieldNode's without an arguments array instead of relying on chaining.

### DIFF
--- a/.changeset/twenty-bears-tap.md
+++ b/.changeset/twenty-bears-tap.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/in-memory-live-query-store": patch
+---
+
+Fix `extractLiveQueryRootFieldCoordinates` to handle `FieldNode`s without an `arguments` array instead of relying on optional chaining alone to support graphql-js 17

--- a/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.spec.ts
+++ b/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.spec.ts
@@ -4,6 +4,7 @@ import { extractLiveQueryRootFieldCoordinates } from "./extractLiveQueryRootFiel
 const schema = buildSchema(/* GraphQL */ `
   type Query {
     node(id: ID!): Node!
+    viewer: Node!
   }
 
   type Node {
@@ -46,4 +47,21 @@ test("collects the correct identifiers", () => {
     typeInfo,
   });
   expect(Array.from(result)).toEqual(["Query.node", `Query.node(id:"1")`]);
+});
+
+test("collects the identifier for a root field without arguments", () => {
+  const documentNode = parse(/* GraphQL */ `
+    query viewer {
+      viewer {
+        id
+      }
+    }
+  `);
+  const operationNode = getOperationAST(documentNode)!;
+  const result = extractLiveQueryRootFieldCoordinates({
+    documentNode,
+    operationNode,
+    typeInfo,
+  });
+  expect(Array.from(result)).toEqual(["Query.viewer"]);
 });

--- a/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
+++ b/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
@@ -64,7 +64,7 @@ export const extractLiveQueryRootFieldCoordinates = (params: {
         if (
           isSome(parentType) &&
           parentType.name === "Query" &&
-          isSome(fieldNode.arguments?.length)
+          isSome((fieldNode.arguments ?? []).length)
         ) {
           const fieldDef = params.typeInfo.getFieldDef();
           identifier.add(`Query.${fieldNode.name.value}`);

--- a/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
+++ b/packages/in-memory-live-query-store/src/extractLiveQueryRootFieldCoordinates.ts
@@ -61,11 +61,7 @@ export const extractLiveQueryRootFieldCoordinates = (params: {
     visitWithTypeInfo(params.typeInfo, {
       Field(fieldNode) {
         const parentType = params.typeInfo.getParentType();
-        if (
-          isSome(parentType) &&
-          parentType.name === "Query" &&
-          isSome((fieldNode.arguments ?? []).length)
-        ) {
+        if (isSome(parentType) && parentType.name === "Query") {
           const fieldDef = params.typeInfo.getFieldDef();
           identifier.add(`Query.${fieldNode.name.value}`);
           if (isSome(fieldDef)) {


### PR DESCRIPTION
Updating Yoga to graphql-js 17 causes in-memory-live-query-store tests to hang.

Root cause: extractLiveQueryRootFieldCoordinates gated on fieldNode.arguments?.length. In graphql-js 16, empty argument lists parse to [], so .length is 0 and isSome(0) is true. In graphql-js 17, empty AST arrays are omitted entirely (undefined), so the optional chain short-circuits to undefined and isSome(undefined) is false — the field's coordinate is never added to the identifier set, so invalidating it never re-triggers the live query, and a test awaiting that re-execution hangs.

Fix: remove the array length check so parser always run

This needs to be fixed before I can move forward with Yoga upgrade. 