### PR TITLE
fix(types): Export LiveExecuteReturnType from InMemoryLiveQueryStore

### DIFF
--- a/.changeset/curvy-plants-invite.md
+++ b/.changeset/curvy-plants-invite.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/in-memory-live-query-store": patch
+---
+
+Export `LiveExecuteReturnType` type from the package entrypoint. It was previously missing the `export` keyword, making it inaccessible to consumers despite being part of the public API (the return type of `execute`/`makeExecute`).

--- a/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
+++ b/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts
@@ -171,7 +171,7 @@ type SchemaCacheRecord = {
   typeInfo: TypeInfo;
 };
 
-type LiveExecuteReturnType = PromiseOrValue<
+export type LiveExecuteReturnType = PromiseOrValue<
   // TODO: change this to AsyncGenerator once we drop support for GraphQL.js 15
   AsyncIterableIterator<ExecutionResult | LiveExecutionResult> | ExecutionResult
 >;


### PR DESCRIPTION
Export `LiveExecuteReturnType` to fix the following issue:

```
The inferred type of 'makeExecute' cannot be named without a reference to '@envelop/live-query/node_modules/@n1ru4l/graphql-live-query'. This is likely not portable. A type annotation is necessary. (ts 2742)
```

The error above comes from this code in my own project:

```ts
  makeExecute(execute: typeof defaultExecute) {
    return this.liveQueryStore.makeExecute(execute)
  }
```

<img width="418" height="281" alt="image" src="https://github.com/user-attachments/assets/22646466-703f-4d47-a9a1-018cee488477" />

A similar issue, the reason TS complains, and the solution, is well described here: https://stackoverflow.com/questions/72041763/typescript-inferred-type-cannot-be-named-without-reference